### PR TITLE
Add mouse over hints on criteria icons

### DIFF
--- a/src/features/videos/VideoCard.tsx
+++ b/src/features/videos/VideoCard.tsx
@@ -207,6 +207,7 @@ function VideoCard({ video }: { video: VideoWithCriteriaScore }) {
                   className={classes.logo}
                   src={`/svg/${max_criteria}.svg`}
                   alt={max_criteria}
+                  title={max_criteria}
                 />
               </div>
               <div className={classes.rated}>
@@ -215,6 +216,7 @@ function VideoCard({ video }: { video: VideoWithCriteriaScore }) {
                   className={classes.logo}
                   src={`/svg/${min_criteria}.svg`}
                   alt={min_criteria}
+                  title={min_criteria}
                 />
               </div>
             </>


### PR DESCRIPTION
This small change adds hints displaying the criteria name when the mouse cursor stays over the low and high rating criteria icons.
This should help with discoverability as the criteria icons are not always self-evident about which criteria is being represented.
The raw name of the criteria is displayed, so it would probably be best to get the display names of the criteria somehow.